### PR TITLE
fix imcompleteness of SpaceTimeAstar when focal_list is empty

### DIFF
--- a/src/SpaceTimeAStar.cpp
+++ b/src/SpaceTimeAStar.cpp
@@ -243,8 +243,12 @@ inline void SpaceTimeAStar::pushNode(AStarNode* node)
     node->open_handle = open_list.push(node);
     node->in_openlist = true;
     num_generated++;
-    if (node->getFVal() <= w * min_f_val)
-        node->focal_handle = focal_list.push(node);
+    if (node->getFVal() <= w * min_f_val || focal_list_.empty()) {
+        node->focal_handle = focal_list.push(node); 
+        if(focal_list_.size() == 1) {
+            this->min_f_val_ = node->getFVal();
+        }
+    }
 }
 
 


### PR DESCRIPTION
I notice when w = 1, and the only node in focal_list was pop out, and new node have f value than w*min_f_val, SpaceTimeAstar will terminate. This phenomenon may also happen when w is close to 1 or there is a few new node.
